### PR TITLE
Update compatibility with seneca@^3.14.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ class PinoLogAdapter {
       // current instance of Seneca plus the raw payload.
       function adapter(context, payload) {
         // Grab the log level before deleting the Seneca level.
-        let level = payload.level
+        let level = payload.level_name
+        if (level == null) level = payload.level
 
         // Avoid duplicate level data in the output.
         delete payload.level

--- a/test/seneca-pino-adapter-tests.js
+++ b/test/seneca-pino-adapter-tests.js
@@ -61,6 +61,8 @@ describe('seneca-pino-adapter-tests', function () {
       const ostream = MemoryStream()
       const logger = Pino({level: 'info'}, ostream)
       const seneca = Seneca({
+        legacy: {logging: false},
+        log: {level: 'debug'},
         internal: {
           logger: new PinoLogAdapter({
             logger: logger


### PR DESCRIPTION
Looks like seneca changed how log payload is defined.  

In older versions "level" was a string, e.g., "debug", "fatal", etc.  This is now a number, 200, 500 - and the "level_name" is the name.  This fix should be backwards compatible.  (Unfortunately this is NOT mentioned in the changelog of 3.14.0)

I also didn't include the `package-lock.json` that was generated from `npm i` -- it might be a good idea to include this if/when this PR is merged

Fixes #2